### PR TITLE
Fix utils imports and inventory logging

### DIFF
--- a/services/inventory_service.py
+++ b/services/inventory_service.py
@@ -23,15 +23,24 @@ class InventoryService:
             # Round to 3 decimal places for precision
             new_quantity = round(inventory.quantity + quantity_change, 3)
             if new_quantity < 0:
-                logger.warning(f"Attempted negative inventory for product {product_id}")
+                logger.warning(
+                    "Attempted negative inventory for product %s", product_id
+                )
                 raise ValidationException("Inventory cannot be negative")
-            InventoryService._modify_inventory(product_id, new_quantity, action="update")
+            InventoryService._modify_inventory(
+                product_id, new_quantity, action="update"
+            )
         else:
             if quantity_change < 0:
                 raise ValidationException(
                     f"Cannot decrease quantity for non-existent inventory item. Product ID: {product_id}"
                 )
-            InventoryService._modify_inventory(product_id, quantity_change, action="create")
+            # When creating a new inventory record the resulting quantity equals
+            # the provided change.
+            new_quantity = round(quantity_change, 3)
+            InventoryService._modify_inventory(
+                product_id, new_quantity, action="create"
+            )
 
         InventoryService.clear_cache()
         event_system.inventory_changed.emit(product_id)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,16 +1,29 @@
-from .helpers import *
-from .decorators import *
-from .exceptions import *
-from .data_handling import excel_exporter
-from .ui import table_items, sound
-from .system import event_system, logger
-from .validation import validators
+"""Utility package providing optional helpers and common functionality.
+
+The submodules in this package are mostly related to the Qt based UI.  Importing
+them unconditionally makes the package unusable in environments where the
+``PySide6`` dependency is not installed (for example, in the unit test
+environment).  To keep import side effects to a minimum we expose the
+submodules lazily and avoid importing them on package initialisation.
+"""
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
 
 __all__ = [
-    "excel_exporter",
-    "table_items",
-    "sound",
-    "event_system",
-    "logger",
-    "validators",
+    "helpers",
+    "decorators",
+    "exceptions",
+    "data_handling",
+    "ui",
+    "system",
+    "validation",
 ]
+
+
+def __getattr__(name: str) -> ModuleType | Any:  # pragma: no cover - passthrough
+    """Dynamically import submodules on first access."""
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- avoid importing optional Qt helpers on package initialisation
- prevent undefined variable in `InventoryService.update_quantity`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68619ae2323c832884f2fbc5f61a1e13